### PR TITLE
add content type for ADFS FederationMetadata.xml

### DIFF
--- a/http/data_source.go
+++ b/http/data_source.go
@@ -92,6 +92,7 @@ func isContentTypeAllowed(contentType string) bool {
 	allowedContentTypes := []*regexp.Regexp{
 		regexp.MustCompile("^text/.+"),
 		regexp.MustCompile("^application/json$"),
+		regexp.MustCompile("^application/samlmetadata\\+xml"),
 	}
 
 	for _, r := range allowedContentTypes {


### PR DESCRIPTION
I would like to be able to pull ADFS federation metadata xml file directly in terraform for creating an AWS IAM SAML Provider

but it fails with error

> data.http.adfs: Content-Type is not a text type. Got: application/samlmetadata+xml

```
data "http" "adfs" {
  url = "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"
}

resource "aws_iam_saml_provider" "adfsprod" {
  name = "adfs.example.com"
  saml_metadata_document = "${data.http.adfs.body}"
}
```

@iceycake