### PR TITLE
Configurable list of headers to avoid writing to tfstate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## 1.1.0 (Unreleased)
+* Allow headers to be redacted in Terraform state
+
 ## 1.0.1 (January 03, 2018)
 
 * Allow `charset` argument on `Content-Type` ([#5](https://github.com/terraform-providers/terraform-provider-http/issues/5))
 
 ## 1.0.0 (September 14, 2017)
 
-* add content type for ADFS FederationMetadata.xml ([#4](https://github.com/terraform-providers/terraform-provider-http/issues/4))
+* Add content type for ADFS FederationMetadata.xml ([#4](https://github.com/terraform-providers/terraform-provider-http/issues/4))
 
 ## 0.1.0 (June 20, 2017)
 

--- a/http/data_source.go
+++ b/http/data_source.go
@@ -33,6 +33,14 @@ func dataSource() *schema.Resource {
 				},
 			},
 
+			"request_headers_redact": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"body": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -56,9 +64,16 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating request: %s", err)
 	}
 
+	redact := d.Get("request_headers_redact").([]interface{})
 	for name, value := range headers {
 		req.Header.Set(name, value.(string))
+		for _, r := range redact {
+			if name == r {
+				headers[name] = "..."
+			}
+		}
 	}
+	d.Set("request_headers", headers)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/website/docs/data_source.html.md
+++ b/website/docs/data_source.html.md
@@ -44,6 +44,9 @@ The following arguments are supported:
 * `request_headers` - (Optional) A map of strings representing additional HTTP
   headers to include in the request.
 
+* `request_headers_redact` - (Optional) A list of header names to avoid writing
+  the values of into Terraform state (eg; `["Authorization"]`).
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
I'd like to avoid writing some headers (eg; "Authorization") to Terraform state...
Not sure what you think about the config name?

The implementation is a little... unusual - it doesn't seem like `StateFunc` applies early enough to data sources (vs resources), so i had to resort to Set() to overwrite the state in the Read function
(ditto for `ImportState` et al for testing state set by a data source).