### PR TITLE
Fix HTTP provider example

### DIFF
--- a/website/docs/data_source.html.md
+++ b/website/docs/data_source.html.md
@@ -28,8 +28,8 @@ data "http" "example" {
   url = "https://checkpoint-api.hashicorp.com/v1/check/terraform"
 
   # Optional request headers
-  request_headers {
-    "Accept" = "application/json"
+  request_headers = {
+    Accept = "application/json"
   }
 }
 ```


### PR DESCRIPTION
The example for the HTTP provider has invalid syntax and does not work.
This PR fixes the two errors.