### PR TITLE
Improve error logging on http calls

### DIFF
--- a/http/data_source.go
+++ b/http/data_source.go
@@ -62,7 +62,7 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Error during making a request: %s", err)
+		return fmt.Errorf("Error making a request: %s", err)
 	}
 
 	defer resp.Body.Close()

--- a/http/data_source.go
+++ b/http/data_source.go
@@ -62,7 +62,7 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("Error during making a request: %s", url)
+		return fmt.Errorf("Error during making a request: %s", err)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
This update changes the behavior of error logging in http call traces to include the URL and actual error message vs. just the URL being called.

Current sample output: 
`err: Error during making a request: https://my.url.com/api/some/data`

Proposed sample output:
`Error during making a request: Get https://my.url.com/api/some/data: dial tcp 10.0.0.23:443: i/o timeout`

Closes #27 

